### PR TITLE
Update scarch5.css

### DIFF
--- a/Styles/scarch5.css
+++ b/Styles/scarch5.css
@@ -451,7 +451,6 @@ table#fees thead tr th {
     color: #777;
     font-size: .9375em;
     font-weight: bold;
-    text-align: left;
     padding: .6250em .5em .50em .5em;
     border-bottom: 1px #bb292d solid;
 }


### PR DESCRIPTION
Remove text-align (line 454) from table#fees tbody tr th style.  I have made this change to the live site; it needs only to be incorporated into the Github repository.